### PR TITLE
Add scheduled X posting workflow

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -1,0 +1,18 @@
+name: Post to X
+on:
+  schedule:
+    - cron: "0 */8 * * *"
+  workflow_dispatch:
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install requests
+      - env:
+          X_BEARER: ${{ secrets.X_BEARER }}
+        run: python bot.py


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to post to X every 8 hours or on demand

## Testing
- `python -m py_compile bot.py` *(fails: IndentationError: unexpected indent (bot.py, line 1))*

------
https://chatgpt.com/codex/tasks/task_e_68a16a14b8ec83329f05a3ba3489ccca